### PR TITLE
Target v2 of Modrinth publish action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           for jar in build/libs/*.jar; do
             cp "$jar" "csgrenade-${TAG}.jar"
           done
-      
+
       - name: Generate Changelog
         id: changelog
         uses: requarks/changelog-action@v1
@@ -57,7 +57,7 @@ jobs:
           asset_content_type: application/java-archive
 
       - name: Push to Modrinth
-        uses: cloudnode-pro/modrinth-publish@2.0.0
+        uses: cloudnode-pro/modrinth-publish@v2
         with:
           token: ${{ secrets.MODRINTH_TOKEN }}
           project: "DfhBvciR"
@@ -70,4 +70,4 @@ jobs:
           files: |-
             csgrenade-${{ github.ref_name }}.jar
           channel: beta
-    
+


### PR DESCRIPTION
Hi! Thanks for using modrinth-publish. To benefit from backwards-compatible SemVer patch & minor releases, we now recommend targeting `v2`.

Alternatively, you can set up [`.github/dependabot.yaml`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) to open a pull request to update to specific versions as they are released.

```yaml
version: 2
updates:
  - package-ecosystem: github-actions
    directory: /
```