### PR TITLE
fix(mods): 降低TACZ依赖版本要求

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -28,6 +28,6 @@ side = "BOTH"
 [[dependencies.${ mod_id }]]
 modId = "tacz"
 mandatory = false
-versionRange = "[1.1.7,)"
+versionRange = "[1.1.5,)"
 ordering = "AFTER"
 side = "BOTH"


### PR DESCRIPTION
- 将TACZ依赖版本范围从[1.1.7,)调整为[1.1.5,)