### PR TITLE
feat(粒子效果): 为诱饵射击添加枪口火焰和烟雾粒子效果

### DIFF
--- a/src/main/kotlin/club/pisquad/minecraft/csgrenades/network/message/DecoyShotMessage.kt
+++ b/src/main/kotlin/club/pisquad/minecraft/csgrenades/network/message/DecoyShotMessage.kt
@@ -1,6 +1,8 @@
 package club.pisquad.minecraft.csgrenades.network.message
 
 import club.pisquad.minecraft.csgrenades.client.sound.DecoySoundController
+import net.minecraft.client.Minecraft
+import net.minecraft.core.particles.ParticleTypes
 import net.minecraft.network.FriendlyByteBuf
 import net.minecraftforge.network.NetworkEvent
 import java.util.function.Supplier
@@ -33,6 +35,40 @@ class DecoyShotMessage(
             context.packetHandled = true
             if (context.direction.receptionSide.isClient) {
                 DecoySoundController.playShotSound(msg.entityId, msg.gunId, msg.customSound)
+                spawnMuzzleFlashParticles(msg.entityId)
+            }
+        }
+
+        private fun spawnMuzzleFlashParticles(entityId: Int) {
+            val mc = Minecraft.getInstance()
+            val level = mc.level ?: return
+            val entity = level.getEntity(entityId) ?: return
+
+            val particleEngine = mc.particleEngine
+            val position = entity.position()
+
+            for (i in 0 until 5) {
+                particleEngine.createParticle(
+                    ParticleTypes.FLAME,
+                    position.x,
+                    position.y + 0.5,
+                    position.z,
+                    (Math.random() - 0.5) * 0.1,
+                    (Math.random() - 0.5) * 0.1 + 0.05,
+                    (Math.random() - 0.5) * 0.1,
+                )?.lifetime = 5
+            }
+
+            for (i in 0 until 3) {
+                particleEngine.createParticle(
+                    ParticleTypes.SMOKE,
+                    position.x,
+                    position.y + 0.5,
+                    position.z,
+                    (Math.random() - 0.5) * 0.05,
+                    (Math.random() - 0.5) * 0.05 + 0.02,
+                    (Math.random() - 0.5) * 0.05,
+                )?.lifetime = 10
             }
         }
     }


### PR DESCRIPTION
在客户端处理诱饵射击消息时，新增枪口火焰和烟雾粒子效果以增强视觉表现。火焰粒子使用5次快速闪烁，烟雾粒子使用3次缓慢扩散

### Link
#93 